### PR TITLE
Update reaction-time-calculator.py

### DIFF
--- a/reaction-time-calculator.py
+++ b/reaction-time-calculator.py
@@ -21,8 +21,8 @@ for i in range(30):
     user_input = raw_input() 
     end_time = time.time()
     react_time = end_time-start_time
-    print("Trial "+str(i+1)+" Reaction Time is "+str(int(round(react_time*1000)))+" milliseconds.\n")
-    res.append(int(round(react_time*1000)))
+    print(f"Trial {i+1} Reaction Time is {int(react_time*1000)} milliseconds.\n")
+    res.append(int(react_time*1000))
     time.sleep(1)
     if i+1 !=30:
         print(colored("Get ready for the next trial!\n", "cyan"))
@@ -30,7 +30,7 @@ for i in range(30):
 
 time.sleep(1)
 #summary of the user's reaction time    
-print("Your average reaction time is "+str(int(round(sum(res) / len(res))))+" milliseconds.")
+print(f"Your average reaction time is {int(sum(res) / len(res))} milliseconds.")
 
 #store the file into csv in unit of milliseconds
 with open('reaction_time_result.csv', 'w') as f: 
@@ -42,4 +42,3 @@ time.sleep(1)
 print(colored("Your reaction time has been recorded.", "cyan"))
 time.sleep(1)
 print(colored("Thank you very much for your participation!", "cyan"))
-

--- a/reaction-time-calculator.py
+++ b/reaction-time-calculator.py
@@ -21,8 +21,8 @@ for i in range(30):
     user_input = raw_input() 
     end_time = time.time()
     react_time = end_time-start_time
-    print(f"Trial {i+1} Reaction Time is {int(react_time*1000)} milliseconds.\n")
-    res.append(int(react_time*1000))
+    print(f"Trial {i+1} Reaction Time is {round(react_time*1000)} milliseconds.\n")
+    res.append(round(react_time*1000))
     time.sleep(1)
     if i+1 !=30:
         print(colored("Get ready for the next trial!\n", "cyan"))
@@ -30,7 +30,7 @@ for i in range(30):
 
 time.sleep(1)
 #summary of the user's reaction time    
-print(f"Your average reaction time is {int(sum(res) / len(res))} milliseconds.")
+print(f"Your average reaction time is {round(sum(res) / len(res))} milliseconds.")
 
 #store the file into csv in unit of milliseconds
 with open('reaction_time_result.csv', 'w') as f: 


### PR DESCRIPTION
I like the reaction time test you created with all the colored CLI text, the collection of multiple times, and the averaging of the times. I have a few enhancements that can reduce the file size and make it look more refined.

- Lines 24 and 33: Since you are using `str()` functions, you can turn an entire string into f-strings, which allows better interpolation and formatting and reduces execution time than using casting calls. Any `str()` functions can turn into curly braces, taking quotes and concatenation operators associated with `str()` functions with them. Also, since what was being printed started with a string, Python will automatically type-cast any primitive data types into strings before concatenating with others.
- Lines 24, 25, and 33: Using `round()` and `int()` together is redundant in this context. `round()` has two parameters: `number` and `digits`. `number` is the number that will get rounded, and `digits` is the number of decimal places used when rounding (ex: `round(3.14159, 2)` will return `3.14`). Since the `digits` argument was omitted to record milliseconds as integers, `round()` will round using zero decimal places, making it an integer. This is redundant because `int()` truncates all decimal places from a float and returns it as an integer, making it equivalent to `round()` without the `digits` argument. To make it more refined, I suggest removing all `round()` calls and letting `int()` take care of the rest.

Those are my enhancements for this file. Any questions, comments, and concerns can go into this pull request. Otherwise, thank you for your time and attention, fellow programmer.